### PR TITLE
Remove need for fonts in Pubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6+2
+
+- Remove need for specifying fonts in package Pubspec.
+
 ## [0.1.6+1] - 2020/8/10
 ## [0.1.6] - 2020/8/10
 - Add support for Flutter Web (DomCanvas backend)

--- a/README.md
+++ b/README.md
@@ -28,69 +28,7 @@ The TeX parser is a completely rewritten Dart port of the KaTeX parser, with alm
 
 
 ## How to use
-Add the following font resources into your pubspec.yaml (under the root `flutter:` tag, not `dependencies:  flutter:`)
-```yaml
-flutter:
 
-  // ......
-
-  fonts:
-    - family: KaTeX_Main
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Main-Regular.ttf
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Main-Italic.ttf
-          style: italic
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Main-Bold.ttf
-          weight: 700
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Main-BoldItalic.ttf
-          weight: 700
-          style: italic
-    - family: KaTeX_Math
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Math-Italic.ttf
-          style: italic
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Math-BoldItalic.ttf
-          weight: 700
-          style: italic
-    - family: KaTeX_AMS
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_AMS-Regular.ttf
-    - family: KaTeX_Caligraphic
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Caligraphic-Regular.ttf
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Caligraphic-Bold.ttf
-          weight: 700
-    - family: KaTeX_Fraktur
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Fraktur-Regular.ttf
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Fraktur-Bold.ttf
-          weight: 700
-    - family: KaTeX_SansSerif
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_SansSerif-Regular.ttf
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_SansSerif-Bold.ttf
-          weight: 700
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_SansSerif-Italic.ttf
-          style: italic
-    - family: KaTeX_Script
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Script-Regular.ttf
-    - family: KaTeX_Typewriter
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Typewriter-Regular.ttf
-    - family: KaTeX_Size1
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Size1-Regular.ttf
-    - family: KaTeX_Size2
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Size2-Regular.ttf
-    - family: KaTeX_Size3
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Size3-Regular.ttf
-    - family: KaTeX_Size4
-      fonts:
-        - asset: packages/flutter_math/katex_fonts/fonts/KaTeX_Size4-Regular.ttf
-```
 ### Mobile
 Currently only Android platform has been tested. If you encounter any issues with iOS, please file them.
 

--- a/lib/src/render/symbols/make_atom.dart
+++ b/lib/src/render/symbols/make_atom.dart
@@ -133,7 +133,7 @@ Widget makeChar(String character, FontOptions font,
     child: Text(
       character,
       style: TextStyle(
-        fontFamily: 'KaTeX_${font.fontFamily}',
+        fontFamily: 'packages/flutter_math/KaTeX_${font.fontFamily}',
         fontWeight: font.fontWeight,
         fontStyle: font.fontShape,
         fontSize: 1.0.cssEm.toLpUnder(options),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_math
 description: Fast and High-quality TeX math equation rendering with pure Dart & Flutter. 
-version: 0.1.6+1
+version: 0.1.6+2
 author: znjameswu <znjameswu@gmail.com>
 homepage: https://github.com/znjameswu/flutter_math
 repository: https://github.com/znjameswu/flutter_math


### PR DESCRIPTION
The previous way was slightly strange.

You can specify the package in the text style, which removes the need for the asset declaration for users.