### PR TITLE
Setting default color to black. Should fix #18.

### DIFF
--- a/lib/src/widgets/math.dart
+++ b/lib/src/widgets/math.dart
@@ -193,7 +193,7 @@ class Math extends StatelessWidget {
             ? FontOptions(fontWeight: effectiveTextStyle.fontWeight)
             : null,
         logicalPpi: logicalPpi,
-        color: textStyle.color,
+        color: textStyle.color ?? Colors.black,
       );
     }
 

--- a/lib/src/widgets/math.dart
+++ b/lib/src/widgets/math.dart
@@ -193,7 +193,7 @@ class Math extends StatelessWidget {
             ? FontOptions(fontWeight: effectiveTextStyle.fontWeight)
             : null,
         logicalPpi: logicalPpi,
-        color: textStyle.color ?? Colors.black,
+        color: effectiveTextStyle.color,
       );
     }
 


### PR DESCRIPTION
The `Math` widget may try to use a color that doesn't exist in the resolved `TextStyle`. As everyone isn't overriding the default text color, it may result in a NPE.

See [this comment](https://github.com/znjameswu/flutter_math/issues/18#issuecomment-744008322) for more info.